### PR TITLE
refactor: move imports to top of file

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1,4 +1,10 @@
-// ...existing code...
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {GoogleGenAI, Modality} from '@google/genai';
+import {marked} from 'marked';
+
 // Função utilitária para baixar arquivo
 function downloadFile(filename: string, blob: Blob) {
   const link = document.createElement('a');
@@ -66,13 +72,6 @@ async function exportImages() {
 }
 
 document.getElementById('export-images')?.addEventListener('click', exportImages);
-/**
- * @license
- * SPDX-License-Identifier: Apache-2.0
- */
-
-import {GoogleGenAI, Modality} from '@google/genai';
-import {marked} from 'marked';
 
 const ai = new GoogleGenAI({apiKey: process.env.GEMINI_API_KEY});
 


### PR DESCRIPTION
## Summary
- remove placeholder comment
- move `@google/genai` and `marked` imports to top

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897ee3d074c8333bd1f9b1c7f7345f1